### PR TITLE
correct vcf path

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Get dummy data, annotation db and configuration file, e.g.
 
 ```
 mkdir data && cd data
-gsutil -mq cp gs://to_solita/vcf/* .
+gsutil -mq cp gs://to_solita/genotype_50k/vcf/* .
 gsutil -mq cp gs://to_solita/genotype_browser/1/* .
 curl https://raw.githubusercontent.com/FINNGEN/genotype_browser/main/config/config.py.dummy -o config.py
 ```

--- a/README.md
+++ b/README.md
@@ -12,9 +12,10 @@ gsutil -mq cp gs://to_solita/genotype_browser/1/* .
 curl https://raw.githubusercontent.com/FINNGEN/genotype_browser/main/config/config.py.dummy -o config.py
 ```
 
-Run container from the above directory
+Build and run container from the above directory
 
 ```
+docker build -t finngen/genotype_browser:6373448 -f docker/Dockerfile .
 docker run -it -p 0.0.0.0:8080:8080/tcp -v `pwd`:/config finngen/genotype_browser:6373448
 ```
 


### PR DESCRIPTION
Completing README with
- correct vcf path (for n=50k)
- add docker build command (to make it clear that there is no image on gcr.io)