### PR TITLE
Fixed cluster plot not found error not caught

### DIFF
--- a/server/cloud_storage.py
+++ b/server/cloud_storage.py
@@ -7,11 +7,12 @@ class CloudStorage:
         # Uses "GOOGLE_APPLICATION_CREDENTIALS" environment variable to get service account key
         self.client = storage.Client()
       
-    def read_file(self, bucket, file):
+    def read_bytes(self, bucket, file):
         try:
             bucket = self.client.bucket(bucket)
+            blob = bucket.blob(file)
+            data = blob.download_as_bytes()
         except google.cloud.exceptions.NotFound:
             return None
-        blob = bucket.blob(file)
             
-        return blob
+        return data

--- a/server/server.py
+++ b/server/server.py
@@ -97,10 +97,9 @@ def clusterplot(plot_type, variant):
         exists_in_chip = fetch.check_var_in_chip(variant)
         filename = config['cluster_plots_location'] + '/' + plot_type + '/' + '_'.join(arr) + '.png'
         if (config['use_gcp_buckets']):
-            blob = cloud_storage.read_file(config['cluster_plots_bucket'], filename)
-            if blob is None:
+            data = cloud_storage.read_bytes(config['cluster_plots_bucket'], filename)
+            if data is None:
                 raise FileNotFoundError("Requested cluster plot not found!")
-            data = blob.download_as_bytes()
         else:
             with open(filename, 'rb') as f:
                 data = f.read()


### PR DESCRIPTION
Puuttuvasta cluster plotista aiheutuva virhe otetaan nyt oikein kiinni ja käyttäjä saa järkevän virheviestin.