### PR TITLE
fix the typo Inf to inf in GeneTable.js

### DIFF
--- a/react/features/gene/GeneTable.js
+++ b/react/features/gene/GeneTable.js
@@ -144,7 +144,7 @@ export const getColumns = (gene, checked, handleCheck, handleCheckAll, dtype) =>
 		Cell: props => {
 			if (props.value == 'NA'){
 				return 'NA'
-			} else if (props.value == 1e6 || props.value == 'Inf') {
+			} else if (props.value == 1e6 || props.value == 'inf') {
 				return 'inf'
 			} else {
 				return props.value.toPrecision(3)

--- a/react/features/gene/GeneTable.js
+++ b/react/features/gene/GeneTable.js
@@ -144,7 +144,7 @@ export const getColumns = (gene, checked, handleCheck, handleCheckAll, dtype) =>
 		Cell: props => {
 			if (props.value == 'NA'){
 				return 'NA'
-			} else if (props.value == 1e6 || props.value == 'inf') {
+			} else if (props.value == 1e6 || props.value == 'inf' || props.value == 'Inf') {
 				return 'inf'
 			} else {
 				return props.value.toPrecision(3)


### PR DESCRIPTION
This was preventing the variant list table from displaying when searching with a gene and the 'enrichment_nfsee' value was inf.